### PR TITLE
20241201 Contextを使ってグローバルなstateを管理する

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from "react";
-import { useMemo as useMemoHook } from "./hooks/useMemo";
+import { useMemo } from "./hooks/useMemo";
 import MemoList from "./components/MemoList";
 import MemoEditor from "./components/MemoEditor";
 import Header from "./components/Header";
@@ -12,7 +12,7 @@ import "./App.css";
 const AppSetUp = () => {
   const [view, setView] = useState(constants.viewType.list);
   const [currentMemo, setCurrentMemo] = useState(null);
-  const { memos, addMemo, saveMemo, deleteMemo } = useMemoHook();
+  const { memos, addMemo, saveMemo, deleteMemo } = useMemo();
   const { session } = useContext(sessionContext);
 
   const handleNewMemo = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,45 +24,38 @@ const MainView = () => {
     setView(constants.viewType.create);
   };
 
-  const renderMemoList = () => (
-    <section>
-      <button onClick={handleNewMemo}>{labels.newMemoButton}</button>
-      <MemoList
-        memos={memos}
-        onMemoClick={(memo) => {
-          setCurrentMemo(memo);
-          setView(constants.viewType.edit);
-        }}
-      />
-    </section>
-  );
-
-  const renderMemoEditor = () => (
-    <section>
-      <MemoEditor
-        memo={currentMemo}
-        onSave={(memo) => {
-          saveMemo(memo);
-          setView(constants.viewType.list);
-        }}
-        onDelete={() => {
-          deleteMemo(currentMemo.id);
-          setView(constants.viewType.list);
-        }}
-        onCancel={() => setView(constants.viewType.list)}
-      />
-    </section>
-  );
-
   return (
     <div>
       <Header />
       <main>
-        {view === constants.viewType.list && renderMemoList()}
-        {(view === constants.viewType.create ||
-          view === constants.viewType.edit) &&
-          currentMemo &&
-          renderMemoEditor()}
+        {view === constants.viewType.list && (
+          <section>
+            <button onClick={handleNewMemo}>{labels.newMemoButton}</button>
+            <MemoList
+              memos={memos}
+              onMemoClick={(memo) => {
+                setCurrentMemo(memo);
+                setView(constants.viewType.edit);
+              }}
+            />
+          </section>
+        )}
+        {(view === constants.viewType.create || view === constants.viewType.edit) && currentMemo && (
+          <section>
+            <MemoEditor
+              memo={currentMemo}
+              onSave={(memo) => {
+                saveMemo(memo);
+                setView(constants.viewType.list);
+              }}
+              onDelete={() => {
+                deleteMemo(currentMemo.id);
+                setView(constants.viewType.list);
+              }}
+              onCancel={() => setView(constants.viewType.list)}
+            />
+          </section>
+        )}
       </main>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import constants from "./constants/constants";
 import SessionProvider, { sessionContext } from "./components/SessionProvider";
 import "./App.css";
 
-const AppSetUp = () => {
+const MainView = () => {
   const [view, setView] = useState(constants.viewType.list);
   const [currentMemo, setCurrentMemo] = useState(null);
   const { memos, addMemo, saveMemo, deleteMemo } = useMemo();
@@ -70,7 +70,7 @@ const AppSetUp = () => {
 
 const App = () => (
   <SessionProvider>
-    <AppSetUp />
+    <MainView />
   </SessionProvider>
 );
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,62 +1,76 @@
-import React from "react";
-import { useState } from "react";
-import { useMemo } from "./hooks/useMemo";
+import React, { useState, useContext } from "react";
+import { useMemo as useMemoHook } from "./hooks/useMemo";
 import MemoList from "./components/MemoList";
 import MemoEditor from "./components/MemoEditor";
 import Header from "./components/Header";
 import labels from "./locales/labels";
+import messages from "./locales/messages";
 import constants from "./constants/constants";
+import SessionProvider, { sessionContext } from "./components/SessionProvider";
 import "./App.css";
 
-const App = () => {
+const AppSetUp = () => {
   const [view, setView] = useState(constants.viewType.list);
   const [currentMemo, setCurrentMemo] = useState(null);
-  const { memos, addMemo, saveMemo, deleteMemo } = useMemo();
+  const { memos, addMemo, saveMemo, deleteMemo } = useMemoHook();
+  const { session } = useContext(sessionContext);
+
+  const handleNewMemo = () => {
+    if (session === "logout") {
+      alert(messages.window.LogInToAddMemo);
+      return;
+    }
+    addMemo(setCurrentMemo);
+    setView(constants.viewType.create);
+  };
+
+  const renderMemoList = () => (
+    <section>
+      <button onClick={handleNewMemo}>{labels.newMemoButton}</button>
+      <MemoList
+        memos={memos}
+        onMemoClick={(memo) => {
+          setCurrentMemo(memo);
+          setView(constants.viewType.edit);
+        }}
+      />
+    </section>
+  );
+
+  const renderMemoEditor = () => (
+    <section>
+      <MemoEditor
+        memo={currentMemo}
+        onSave={(memo) => {
+          saveMemo(memo);
+          setView(constants.viewType.list);
+        }}
+        onDelete={() => {
+          deleteMemo(currentMemo.id);
+          setView(constants.viewType.list);
+        }}
+        onCancel={() => setView(constants.viewType.list)}
+      />
+    </section>
+  );
 
   return (
     <div>
       <Header />
       <main>
-        {view === constants.viewType.list && (
-          <section>
-            <button
-              onClick={() => {
-                addMemo(setCurrentMemo);
-                setView(constants.viewType.create);
-              }}
-            >
-              {labels.newMemoButton}
-            </button>
-            <MemoList
-              memos={memos}
-              onMemoClick={(memo) => {
-                setCurrentMemo(memo);
-                setView(constants.viewType.edit);
-              }}
-            />
-          </section>
-        )}
-        {(view === constants.viewType.create ||
-          view === constants.viewType.edit) &&
-          currentMemo && (
-            <section>
-              <MemoEditor
-                memo={currentMemo}
-                onSave={(memo) => {
-                  saveMemo(memo);
-                  setView(constants.viewType.list);
-                }}
-                onDelete={() => {
-                  deleteMemo(currentMemo.id);
-                  setView(constants.viewType.list)
-                }}
-                onCancel={() => setView(constants.viewType.list)}
-              />
-            </section>
-          )}
+        {view === constants.viewType.list && renderMemoList()}
+        {(view === constants.viewType.create || view === constants.viewType.edit) &&
+          currentMemo &&
+          renderMemoEditor()}
       </main>
     </div>
   );
 };
+
+const App = () => (
+  <SessionProvider>
+    <AppSetUp />
+  </SessionProvider>
+);
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,7 +59,8 @@ const AppSetUp = () => {
       <Header />
       <main>
         {view === constants.viewType.list && renderMemoList()}
-        {(view === constants.viewType.create || view === constants.viewType.edit) &&
+        {(view === constants.viewType.create ||
+          view === constants.viewType.edit) &&
           currentMemo &&
           renderMemoEditor()}
       </main>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { useContext } from "react";
 import texts from "../locales/texts";
+import labels from "../locales/labels";
+import { sessionContext } from "./SessionProvider";
 
-const Header = () => (
-  <header>
-    <h1>{texts.appTitle}</h1>
-  </header>
-);
+const Header = () => {
+  const { session, login, logout } = useContext(sessionContext);
+  
+  return (
+    <header>
+      <h1>{texts.appTitle}</h1>
+      <button onClick={session === "login" ? logout : login}>
+        {session === "login" ? labels.logOutButton : labels.logInButton}
+      </button>
+    </header>
+  );
+};
 
 export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,7 +5,7 @@ import { sessionContext } from "./SessionProvider";
 
 const Header = () => {
   const { session, login, logout } = useContext(sessionContext);
-  
+
   return (
     <header>
       <h1>{texts.appTitle}</h1>

--- a/src/components/MemoEditor.jsx
+++ b/src/components/MemoEditor.jsx
@@ -1,30 +1,52 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import labels from "../locales/labels";
 import constants from "../constants/constants";
 import texts from "../locales/texts";
+import { sessionContext } from "../components/SessionProvider";
 
 const MemoEditor = ({ memo, onSave, onDelete, onCancel }) => {
   const [content, setContent] = useState(memo.content);
+  const { session } = useContext(sessionContext);
 
   const handleSave = () => {
     onSave({ ...memo, content });
   };
 
+  const handleTitle = () => {
+    if (memo.id && session === "logout") {
+      return texts.showMemoTitle;
+    }
+    return memo.id ? texts.editMemoTitle : texts.newMemoTitle;
+  };
+
+  const renderTextarea = () => (
+    <textarea
+      value={content}
+      onChange={(e) => setContent(e.target.value)}
+      rows={constants.textarea.rows}
+      cols={constants.textarea.cols}
+      placeholder={texts.editorPlaceholder}
+      disabled={session === "logout"}
+    />
+  );
+
+  const renderButtons = () => (
+    <div>
+      {session === "login" && (
+        <>
+          <button onClick={handleSave}>{labels.saveButton}</button>
+          {memo.id && <button onClick={onDelete}>{labels.deleteButton}</button>}
+        </>
+      )}
+      <button onClick={onCancel}>{labels.cancelButton}</button>
+    </div>
+  );
+
   return (
     <div>
-      <h2>{memo.id ? texts.editMemoTitle : texts.newMemoTitle}</h2>
-      <textarea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        rows={constants.textarea.rows}
-        cols={constants.textarea.cols}
-        placeholder={texts.editorPlaceholder}
-      />
-      <div>
-        <button onClick={handleSave}>{labels.saveButton}</button>
-        {memo.id && <button onClick={onDelete}>{labels.deleteButton}</button>}
-        <button onClick={onCancel}>{labels.cancelButton}</button>
-      </div>
+      <h2>{handleTitle()}</h2>
+      {renderTextarea()}
+      {renderButtons()}
     </div>
   );
 };

--- a/src/components/SessionProvider.jsx
+++ b/src/components/SessionProvider.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from "react";
+import { createContext } from "react";
+
+export const sessionContext = createContext();
+
+const SessionProvider = ({ children }) => {
+  const [session, setSession] = useState('logout');
+  
+  const login = () => setSession('login');
+  const logout = () => setSession('logout');
+
+  return (
+    <sessionContext.Provider value={{ session, login, logout }}>
+      {children}
+    </sessionContext.Provider>
+  );
+};
+
+export default SessionProvider;

--- a/src/components/SessionProvider.jsx
+++ b/src/components/SessionProvider.jsx
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { createContext } from "react";
+import React, { useState, createContext } from "react";
 
 export const sessionContext = createContext();
 

--- a/src/components/SessionProvider.jsx
+++ b/src/components/SessionProvider.jsx
@@ -4,10 +4,10 @@ import { createContext } from "react";
 export const sessionContext = createContext();
 
 const SessionProvider = ({ children }) => {
-  const [session, setSession] = useState('logout');
-  
-  const login = () => setSession('login');
-  const logout = () => setSession('logout');
+  const [session, setSession] = useState("logout");
+
+  const login = () => setSession("login");
+  const logout = () => setSession("logout");
 
   return (
     <sessionContext.Provider value={{ session, login, logout }}>

--- a/src/index.js
+++ b/src/index.js
@@ -6,5 +6,5 @@ const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.jsx";
+import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
+import App from "./App.jsx";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/src/locales/labels.jsx
+++ b/src/locales/labels.jsx
@@ -3,6 +3,8 @@ const labels = {
   saveButton: "保存",
   deleteButton: "削除",
   cancelButton: "キャンセル",
+  logInButton: "ログイン",
+  logOutButton: "ログアウト",
 };
 
 export default labels;

--- a/src/locales/messages.jsx
+++ b/src/locales/messages.jsx
@@ -1,6 +1,7 @@
 const messages = {
   window: {
     confirmDelete: "メモを削除しますか？",
+    LogInToAddMemo: "メモを作成するにはログインしてください",
   },
   log: {
     noMemo: "メモがありません",

--- a/src/locales/texts.jsx
+++ b/src/locales/texts.jsx
@@ -3,6 +3,7 @@ const texts = {
   listMemosTitle: "メモ一覧",
   newMemoTitle: "メモ作成",
   editMemoTitle: "メモ編集",
+  showMemoTitle: "メモ閲覧",
   editorPlaceholder: "メモ内容を入力してください...",
   noContent: "無題",
   emptyString: "",


### PR DESCRIPTION
## プラクティス
[Contextを使ってグローバルなstateを管理する](https://bootcamp.fjord.jp/practices/263)

## 実装内容
### ログイン/ログアウトボタン
- ログイン時：「ログアウト」
- ログアウト時：「ログイン」
<img width="710" alt="image" src="https://github.com/user-attachments/assets/84f9494d-ca66-4d5c-9c9a-e6ff97b2bb77">
<img width="715" alt="image" src="https://github.com/user-attachments/assets/b5dba2ff-a43e-49f2-ab3e-66b676bb46a0">

### 新規メモボタン押下時の対応
- ログイン時：メモ作成画面に遷移
- 非ログイン時：メッセージ「メモを作成するにはログインしてください」表示
- ログイン時メモ作成画面に遷移後にログアウト時：テキストエリアがブロック&保存ボタン非表示
<img width="719" alt="image" src="https://github.com/user-attachments/assets/49d0daa8-865a-4685-82c6-72b70d1df2a6">
<img width="956" alt="image" src="https://github.com/user-attachments/assets/c9e780f2-6a48-40b0-b948-6088e003303f">
<img width="716" alt="image" src="https://github.com/user-attachments/assets/26370df3-c50b-469d-a2f9-356a6a6a21b6">

### メモ編集画面の対応
- ログイン時：メモ編集/保存/削除可能
- 非ログイン時：メモ閲覧のみ可能
<img width="722" alt="image" src="https://github.com/user-attachments/assets/e3e98794-965d-4c85-adbd-a49e5ce3e780">
<img width="715" alt="image" src="https://github.com/user-attachments/assets/c2ada5cf-9456-4917-acb4-59ec6c110caa">

## ESLint実行結果
```
chiroru@MacBook-Pro-4 spa-memo % npx eslint src/          
chiroru@MacBook-Pro-4 spa-memo %
```
<img width="682" alt="image" src="https://github.com/user-attachments/assets/521e78ba-5350-42d9-b2f7-75eabbc3932a">


## Prettier実行結果
```
chiroru@MacBook-Pro-4 spa-memo % npx prettier --check src/
Checking formatting...
All matched files use Prettier code style!
```
<img width="820" alt="image" src="https://github.com/user-attachments/assets/68da734d-59dd-442a-ad56-7cbbdf929b89">
